### PR TITLE
Ability to rescale mesh in Mesh.from_geometry

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -32,4 +32,4 @@ jobs:
         run: ruff format --diff .
 
       - name: Run static analysis with Ruff
-        run: ruff check --output-format=github --extend-exclude=tests .
+        run: ruff check --output-format=github --extend-exclude=tests,examples .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,11 @@ jobs:
         run: |
           python -m pip install -r requirements.ci.txt
 
+      - name: Reinstall gmsh via conda-forge
+        shell: _entrypoint.sh /bin/bash --noprofile --norc -eo pipefail {0}
+        run: |
+          micromamba install -c conda-forge -c cadquery python-gmsh --force-reinstall -y
+
       - name: Download OpenMC data
         shell: _entrypoint.sh /bin/bash --noprofile --norc -eo pipefail {0}
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up conda dependencies
         shell: _entrypoint.sh /bin/bash --noprofile --norc -eo pipefail {0}
         run: |
-          micromamba install -c conda-forge -c cadquery python=${{ matrix.python-version }} moab openmc=0.15.0=dagmc*nompi* cadquery=master
+          micromamba install -c conda-forge -c cadquery python=${{ matrix.python-version }} moab openmc=0.15.0=dagmc*nompi* cadquery=master python-gmsh
 
       - name: Install dependencies
         shell: _entrypoint.sh /bin/bash --noprofile --norc -eo pipefail {0}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up conda dependencies
         shell: _entrypoint.sh /bin/bash --noprofile --norc -eo pipefail {0}
         run: |
-          micromamba install -c conda-forge python=${{ matrix.python-version }} moab openmc=0.15.0=dagmc*nompi*
+          micromamba install -c conda-forge -c cadquery python=${{ matrix.python-version }} moab openmc=0.15.0=dagmc*nompi* cadquery=master
 
       - name: Install dependencies
         shell: _entrypoint.sh /bin/bash --noprofile --norc -eo pipefail {0}

--- a/requirements.ci.txt
+++ b/requirements.ci.txt
@@ -2,5 +2,4 @@
 .
 pytest
 build123d
-cadquery
 openmc_data_downloader

--- a/src/stellarmesh/mesh.py
+++ b/src/stellarmesh/mesh.py
@@ -126,9 +126,9 @@ class Mesh:
             # Scale volumes is scaling factor was specified
             if scale_factor is not None:
                 logger.info(f"Scaling volumes by factor {scale_factor}")
-                all_volumes = gmsh.model.getEntities(dim=3)
+                dim_tags = gmsh.model.getEntities(dim=dim)
                 gmsh.model.occ.dilate(
-                    all_volumes, 0.0, 0.0, 0.0, scale_factor, scale_factor, scale_factor
+                    dim_tags, 0.0, 0.0, 0.0, scale_factor, scale_factor, scale_factor
                 )
                 gmsh.model.occ.synchronize()
 

--- a/src/stellarmesh/mesh.py
+++ b/src/stellarmesh/mesh.py
@@ -77,7 +77,7 @@ class Mesh:
             gmsh.write(filename)
 
     @classmethod
-    def from_geometry(
+    def from_geometry(  # noqa: PLR0913
         cls,
         geometry: Geometry,
         min_mesh_size: float = 50,
@@ -97,8 +97,9 @@ class Mesh:
             min_mesh_size: Min mesh element size. Defaults to 50.
             max_mesh_size: Max mesh element size. Defaults to 50.
             dim: Generate a mesh up to this dimension. Defaults to 2.
-            num_threads: Max number of threads to use when GMSH compiled with OpenMP
+            num_threads: Max number of threads to use when Gmsh compiled with OpenMP
             support. 0 for system default i.e. OMP_NUM_THREADS. Defaults to None.
+            scale_factor: Scaling factor for geometry. Defaults to None.
         """
         logger.info(f"Meshing solids with mesh size {min_mesh_size}, {max_mesh_size}")
 

--- a/src/stellarmesh/mesh.py
+++ b/src/stellarmesh/mesh.py
@@ -126,7 +126,7 @@ class Mesh:
             # Scale volumes is scaling factor was specified
             if scale_factor is not None:
                 logger.info(f"Scaling volumes by factor {scale_factor}")
-                dim_tags = gmsh.model.getEntities(dim=dim)
+                dim_tags = gmsh.model.getEntities(dim=3)
                 gmsh.model.occ.dilate(
                     dim_tags, 0.0, 0.0, 0.0, scale_factor, scale_factor, scale_factor
                 )

--- a/src/stellarmesh/mesh.py
+++ b/src/stellarmesh/mesh.py
@@ -85,6 +85,7 @@ class Mesh:
         dim: int = 2,
         *,
         num_threads: Optional[int] = None,
+        scale_factor: Optional[float] = None,
     ) -> Mesh:
         """Mesh solids with Gmsh.
 
@@ -120,6 +121,15 @@ class Mesh:
                     material_solid_map[m].append(solid_tag)
 
             gmsh.model.occ.synchronize()
+
+            # Scale volumes is scaling factor was specified
+            if scale_factor is not None:
+                logger.info(f"Scaling volumes by factor {scale_factor}")
+                all_volumes = gmsh.model.getEntities(dim=3)
+                gmsh.model.occ.dilate(
+                    all_volumes, 0.0, 0.0, 0.0, scale_factor, scale_factor, scale_factor
+                )
+                gmsh.model.occ.synchronize()
 
             for material, solid_tags in material_solid_map.items():
                 gmsh.model.add_physical_group(3, solid_tags, name=f"mat:{material}")

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -22,7 +22,7 @@ def test_mesh_geometry_3d(geom_bd_sphere):
     sm.Mesh.from_geometry(geom_bd_sphere, 5, 5, dim=3)
 
 
-def test_mesh_scale_factor(geom_bd_sphere):
+def test_scale_factor(geom_bd_sphere):
     mesh = sm.Mesh.from_geometry(geom_bd_sphere, 5, 5, scale_factor=0.1)
 
     # Get coordinates of mesh nodes and shape into (N, 3)

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -1,4 +1,5 @@
 import build123d as bd
+import gmsh
 import pytest
 import stellarmesh as sm
 
@@ -19,3 +20,16 @@ def test_threads(geom_bd_sphere):
 
 def test_mesh_geometry_3d(geom_bd_sphere):
     sm.Mesh.from_geometry(geom_bd_sphere, 5, 5, dim=3)
+
+
+def test_mesh_scale_factor(geom_bd_sphere):
+    mesh = sm.Mesh.from_geometry(geom_bd_sphere, 5, 5, scale_factor=0.1)
+
+    # Get coordinates of mesh nodes and shape into (N, 3)
+    with mesh:
+        _, coords, _ = gmsh.model.mesh.getNodes()
+    coords.shape = (-1, 3)
+
+    # Check that coordinates are within a sphere of radius 1
+    assert (coords.min(axis=0) >= -1.0).all()
+    assert (coords.max(axis=0) <= 1.0).all()


### PR DESCRIPTION
I've come across several STEP files where units are expressed in [mm]. To generate a mesh for use with OpenMC, the units need to be in [cm], which means a scaling factor is needed at the point the mesh is produced. This PR implements a new `scale_factor` argument in `Mesh.from_geometry` that enables this.