### PR TITLE
Add option to set MeshSizeFromCurvature

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,12 +35,7 @@ jobs:
       - name: Install dependencies
         shell: _entrypoint.sh /bin/bash --noprofile --norc -eo pipefail {0}
         run: |
-          python -m pip install -r requirements.ci.txt
-
-      - name: Reinstall gmsh via conda-forge
-        shell: _entrypoint.sh /bin/bash --noprofile --norc -eo pipefail {0}
-        run: |
-          micromamba install -c conda-forge python-gmsh --force-reinstall -y
+          python -m pip install --no-deps -r requirements.ci.txt
 
       - name: Download OpenMC data
         shell: _entrypoint.sh /bin/bash --noprofile --norc -eo pipefail {0}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up conda dependencies
         shell: _entrypoint.sh /bin/bash --noprofile --norc -eo pipefail {0}
         run: |
-          micromamba install -c conda-forge -c cadquery python=${{ matrix.python-version }} moab openmc=0.15.0=dagmc*nompi* cadquery=master python-gmsh
+          micromamba install -c conda-forge python=${{ matrix.python-version }} moab openmc=0.15.0=dagmc*nompi* cadquery python-gmsh
 
       - name: Install dependencies
         shell: _entrypoint.sh /bin/bash --noprofile --norc -eo pipefail {0}
@@ -40,7 +40,7 @@ jobs:
       - name: Reinstall gmsh via conda-forge
         shell: _entrypoint.sh /bin/bash --noprofile --norc -eo pipefail {0}
         run: |
-          micromamba install -c conda-forge -c cadquery python-gmsh --force-reinstall -y
+          micromamba install -c conda-forge python-gmsh --force-reinstall -y
 
       - name: Download OpenMC data
         shell: _entrypoint.sh /bin/bash --noprofile --norc -eo pipefail {0}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       options: --user=root
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.12"]
 
     steps:
       - name: Install system packages
@@ -30,7 +30,7 @@ jobs:
       - name: Set up conda dependencies
         shell: _entrypoint.sh /bin/bash --noprofile --norc -eo pipefail {0}
         run: |
-          micromamba install -c conda-forge python=${{ matrix.python-version }} moab openmc=0.15.0=dagmc*nompi* cadquery python-gmsh
+          micromamba install -c conda-forge python=${{ matrix.python-version }} moab openmc=0.15.0=dagmc*nompi* cadquery python-gmsh build123d
 
       - name: Install dependencies
         shell: _entrypoint.sh /bin/bash --noprofile --norc -eo pipefail {0}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,15 +27,20 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up conda dependencies
+      - name: Install dependencies from conda-forge
         shell: _entrypoint.sh /bin/bash --noprofile --norc -eo pipefail {0}
         run: |
           micromamba install -c conda-forge python=${{ matrix.python-version }} moab openmc=0.15.0=dagmc*nompi* cadquery python-gmsh build123d
 
-      - name: Install dependencies
+      - name: Install dependencies from PyPI
         shell: _entrypoint.sh /bin/bash --noprofile --norc -eo pipefail {0}
         run: |
-          python -m pip install --no-deps -r requirements.ci.txt
+          python -m pip install -r requirements.ci.txt
+
+      - name: Install stellarmesh
+        shell: _entrypoint.sh /bin/bash --noprofile --norc -eo pipefail {0}
+        run: |
+          python -m pip install --no-deps .
 
       - name: Download OpenMC data
         shell: _entrypoint.sh /bin/bash --noprofile --norc -eo pipefail {0}

--- a/requirements.ci.txt
+++ b/requirements.ci.txt
@@ -1,6 +1,4 @@
 # Use requirements.txt as PyPi will not accept a git dependency
-.
 pytest
 pymmg
 openmc_data_downloader
-retry

--- a/requirements.ci.txt
+++ b/requirements.ci.txt
@@ -3,3 +3,4 @@
 pytest
 pymmg
 openmc_data_downloader
+retry

--- a/requirements.ci.txt
+++ b/requirements.ci.txt
@@ -1,5 +1,4 @@
 # Use requirements.txt as PyPi will not accept a git dependency
 .
 pytest
-build123d
 openmc_data_downloader

--- a/requirements.ci.txt
+++ b/requirements.ci.txt
@@ -1,4 +1,5 @@
 # Use requirements.txt as PyPi will not accept a git dependency
 .
 pytest
+pymmg
 openmc_data_downloader

--- a/src/stellarmesh/mesh.py
+++ b/src/stellarmesh/mesh.py
@@ -153,6 +153,7 @@ class Mesh:
         geometry: Geometry,
         min_mesh_size: float = 50,
         max_mesh_size: float = 50,
+        curvature_mesh_size: int = 0,
         dim: int = 2,
     ) -> Mesh:
         """Mesh solids with Gmsh.
@@ -164,6 +165,9 @@ class Mesh:
             geometry: Geometry to be meshed.
             min_mesh_size: Min mesh element size. Defaults to 50.
             max_mesh_size: Max mesh element size. Defaults to 50.
+            curvature_mesh_size: If set to a positive value, the mesh will be
+            adapted with respect to the curvature of the model entities. The value
+            giving the target number of elements per 2 Pi radians. Defaults to 0.
             dim: Generate a mesh up to this dimension. Defaults to 2.
         """
         warnings.warn(
@@ -171,7 +175,11 @@ class Mesh:
             FutureWarning,
             stacklevel=2,
         )
-        return cls.from_geometry(geometry, min_mesh_size, max_mesh_size, dim)
+        return cls.from_geometry(geometry,
+                                 min_mesh_size,
+                                 max_mesh_size,
+                                 curvature_mesh_size,
+                                 dim)
 
     def render(
         self,

--- a/src/stellarmesh/mesh.py
+++ b/src/stellarmesh/mesh.py
@@ -175,11 +175,9 @@ class Mesh:
             FutureWarning,
             stacklevel=2,
         )
-        return cls.from_geometry(geometry,
-                                 min_mesh_size,
-                                 max_mesh_size,
-                                 curvature_mesh_size,
-                                 dim)
+        return cls.from_geometry(
+            geometry, min_mesh_size, max_mesh_size, curvature_mesh_size, dim
+        )
 
     def render(
         self,

--- a/src/stellarmesh/mesh.py
+++ b/src/stellarmesh/mesh.py
@@ -82,6 +82,7 @@ class Mesh:
         geometry: Geometry,
         min_mesh_size: float = 50,
         max_mesh_size: float = 50,
+        curvature_mesh_size: int = 0,
         dim: int = 2,
         *,
         num_threads: Optional[int] = None,
@@ -96,6 +97,9 @@ class Mesh:
             geometry: Geometry to be meshed.
             min_mesh_size: Min mesh element size. Defaults to 50.
             max_mesh_size: Max mesh element size. Defaults to 50.
+            curvature_mesh_size: If set to a positive value, the mesh will be
+            adapted with respect to the curvature of the model entities. The value
+            giving the target number of elements per 2 Pi radians. Defaults to 0.
             dim: Generate a mesh up to this dimension. Defaults to 2.
             num_threads: Max number of threads to use when Gmsh compiled with OpenMP
             support. 0 for system default i.e. OMP_NUM_THREADS. Defaults to None.
@@ -137,6 +141,7 @@ class Mesh:
 
             gmsh.option.set_number("Mesh.MeshSizeMin", min_mesh_size)
             gmsh.option.set_number("Mesh.MeshSizeMax", max_mesh_size)
+            gmsh.option.set_number("Mesh.MeshSizeFromCurvature", curvature_mesh_size)
             gmsh.model.mesh.generate(dim)
 
             mesh._save_changes(save_all=True)


### PR DESCRIPTION
## Intro
By setting the Gmsh's `Mesh.MeshSizeFromCurvature` variable, the mesh can adapt to areas of high-curvature without the need to reduce the maximum mesh size. This is particularly useful for features with areas of high-curvature (like stellarator walls) and can result in significant time savings and avoids the need to over-define the mesh in other areas. Example included below.
## Defining MeshSizeFromCurvature
From the Gmsh [user manual](https://gmsh.info/doc/texinfo/gmsh.html#Specifying-mesh-element-sizes):
"if `Mesh.MeshSizeFromCurvature` is set to a positive value (it is set to 0 by default), the mesh will be adapted with respect to the curvature of the model entities, the value giving the target number of elements per 2 Pi radians."

Therefore, the higher value the more elements gmsh will try and place the curve. The curvature is set similar to the maximum and minimum mesh sizes:
```python
mesh = sm.Mesh.from_geometry(sm_geometry,
                            max_mesh_size=5,
                            min_mesh_size=0.001,
                            curvature_mesh_size=48,
                            )
```

## Example
### Tears in the mesh
Meshing a 2 mm thick stellarator wall with a maximum mesh size = 5, minimum = 0.001, only took  6.1 seconds to mesh on my local machine. However, the mesh contains many small tears around areas of high-curvature that I was unable to fix with DAGMC's `make_watertight`. 
![image](https://github.com/user-attachments/assets/e4575680-aefd-4e48-a2e6-1b28e6f7a494)
### Reducing Maxmim Mesh Size
I found that setting the maximum mesh size very low, to ~1, did resolve the issue. But meshing took **much** longer, 197 seconds, and consequently overly defines the mesh in most areas. This solution also seems impractical for a model with many thin objects like this.
![image](https://github.com/user-attachments/assets/b15c0d07-6195-476f-b79c-fcb55f14f395)
### Setting Mesh Curvature
Through some trial and error, I found that by setting the `curvature_mesh_size=48` , I could keep maximum mesh size high (`max_mesh_size=5`) and the mesh is able to adapt the areas of high-curvature and create a model that is watertight and meshed in 16.1 seconds, yay!
![image](https://github.com/user-attachments/assets/a9175ee0-136c-465f-b035-784f5df9b48a)
