### PR TITLE
Non-solid surface geometry and boundary conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Stellarmesh is a meshing library for nuclear workflows. Principally, it supports
 - [x] Import of [CadQuery](https://github.com/CadQuery/cadquery), [build123d](https://github.com/gumyr/build123d), STEP and BREP geometry
 - [x] Surface and volume meshing
 - [x] Gmsh and OpenCASCADE meshing backends
+- [x] Surface boundary conditions
 - [x] Linear and angular mesh tolerances
 - [x] Imprinting and merging of conformal geometry
 - [x] Mesh refinement

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,9 @@ ignore = [
 ]
 pydocstyle.convention = "google"
 
+[tool.ruff.lint.extend-per-file-ignores]
+"tests/**/test_*.py" = ["F811"] # Variable redefinition (required for fixtures)
+
 
 [tool.pyright]
 pythonVersion = "3.11"

--- a/src/stellarmesh/geometry.py
+++ b/src/stellarmesh/geometry.py
@@ -8,17 +8,14 @@ desc: Geometry class represents a CAD geometry to be meshed.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 import logging
 import warnings
 from typing import (
     Protocol,
     Sequence,
     TypeVar,
-    Union,
     overload,
     runtime_checkable,
-    Literal,
 )
 
 from build123d import Optional, Type
@@ -31,7 +28,7 @@ try:
     from OCP.STEPControl import STEPControl_Reader
     from OCP.TopAbs import TopAbs_ShapeEnum
     from OCP.TopExp import TopExp_Explorer
-    from OCP.TopoDS import TopoDS, TopoDS_Shape, TopoDS_Solid, TopoDS_Face, TopoDS_Shell
+    from OCP.TopoDS import TopoDS, TopoDS_Face, TopoDS_Shape, TopoDS_Shell, TopoDS_Solid
 except ImportError as e:
     raise ImportError(
         "OCP not found. See Stellarmesh installation instructions."

--- a/src/stellarmesh/geometry.py
+++ b/src/stellarmesh/geometry.py
@@ -36,21 +36,22 @@ except ImportError as e:
 
 logger = logging.getLogger(__name__)
 
-_OCP_Shape = TypeVar("_OCP_Shape", bound=TopoDS_Shape)
 
-
-@runtime_checkable
 class Face(Protocol):
+    """Interface for a CadQuery or Build123d Face."""
+
     wrapped: TopoDS_Face | None
 
 
-@runtime_checkable
 class Shell(Protocol):
+    """Interface for a CadQuery or Build123d Shell."""
+
     wrapped: TopoDS_Shell | None
 
 
-@runtime_checkable
 class Solid(Protocol):
+    """Interface for a CadQuery or Build123d Solid."""
+
     wrapped: TopoDS_Solid | None
 
 
@@ -82,14 +83,16 @@ class Geometry:
         """
         if (solids and not material_names) or (material_names and not solids):
             raise ValueError(
-                "If solids or material_names are provided, both must be provided and match in length."
+                "If solids or material_names are provided"
+                ", both must be provided and match in length."
             )
 
         if (surfaces and not surface_boundary_conditions) or (
             surface_boundary_conditions and not surfaces
         ):
             raise ValueError(
-                "If surfaces or surface_boundary_conditions are provided, both must be provided and match in length."
+                "If surfaces or surface_boundary_conditions are provided"
+                ", both must be provided and match in length."
             )
 
         self.solids = []
@@ -114,14 +117,16 @@ class Geometry:
             for i, (s, bc) in enumerate(
                 zip(surfaces, surface_boundary_conditions, strict=True)
             ):
-                if isinstance(s, (Face, Shell)):
-                    if s.wrapped is None:
-                        raise ValueError(
-                            f"{s} {i} has no wrapped TopoDS_Shape. Is it valid?"
-                        )
-                    s_wrapped = s.wrapped
-                else:
-                    s_wrapped = s
+                s_wrapped = (
+                    s
+                    if isinstance(s, (TopoDS_Face, TopoDS_Shell))
+                    else getattr(s, "wrapped", None)
+                )
+
+                if s.wrapped is None:  # type: ignore
+                    raise ValueError(
+                        f"{s} {i} has no wrapped TopoDS_Shape. Is it valid?"
+                    )
 
                 if isinstance(s_wrapped, TopoDS_Face):
                     self.faces.append(s_wrapped)

--- a/src/stellarmesh/geometry.py
+++ b/src/stellarmesh/geometry.py
@@ -62,13 +62,13 @@ class Geometry:
 
     solids: list[TopoDS_Solid]
     material_names: list[str]
-    surfaces: list[TopoDS_Face]
-    surface_boundary_conditions: list[str]
+    faces: list[TopoDS_Face]
+    face_boundary_conditions: list[str]
 
     def __init__(
         self,
-        solids: Optional[Sequence[Solid | TopoDS_Solid]],
-        material_names: Optional[Sequence[str]],
+        solids: Optional[Sequence[Solid | TopoDS_Solid]] = None,
+        material_names: Optional[Sequence[str]] = None,
         surfaces: Optional[Sequence[Face | Shell | TopoDS_Face | TopoDS_Shell]] = None,
         surface_boundary_conditions: Optional[Sequence[str]] = None,
     ):
@@ -111,8 +111,8 @@ class Geometry:
                 self.solids.append(s_wrapped)
                 self.material_names.append(mat_name)
 
-        self.surfaces = []
-        self.surface_boundary_conditions = []
+        self.faces = []
+        self.face_boundary_conditions = []
         if surfaces and surface_boundary_conditions:
             for i, (s, bc) in enumerate(
                 zip(surfaces, surface_boundary_conditions, strict=True)
@@ -127,12 +127,12 @@ class Geometry:
                     s_wrapped = s
 
                 if isinstance(s_wrapped, TopoDS_Face):
-                    self.surfaces.append(s_wrapped)
-                    self.surface_boundary_conditions.append(bc)
+                    self.faces.append(s_wrapped)
+                    self.face_boundary_conditions.append(bc)
                 elif isinstance(s_wrapped, TopoDS_Shell):
                     child_faces = self._get_child_shapes(s_wrapped, TopoDS_Face)
-                    self.surfaces.extend(child_faces)
-                    self.surface_boundary_conditions.extend([bc] * len(child_faces))
+                    self.faces.extend(child_faces)
+                    self.face_boundary_conditions.extend([bc] * len(child_faces))
 
                 else:
                     raise TypeError(

--- a/src/stellarmesh/geometry.py
+++ b/src/stellarmesh/geometry.py
@@ -11,9 +11,17 @@ from __future__ import annotations
 from dataclasses import dataclass
 import logging
 import warnings
-from typing import Protocol, Sequence, Union, overload, runtime_checkable
+from typing import (
+    Protocol,
+    Sequence,
+    TypeVar,
+    Union,
+    overload,
+    runtime_checkable,
+    Literal,
+)
 
-from build123d import Optional
+from build123d import Optional, Type
 
 try:
     from OCP.BOPAlgo import BOPAlgo_MakeConnected
@@ -30,6 +38,8 @@ except ImportError as e:
     ) from e
 
 logger = logging.getLogger(__name__)
+
+_OCP_Shape = TypeVar("_OCP_Shape", bound=TopoDS_Shape)
 
 
 @runtime_checkable
@@ -52,7 +62,7 @@ class Geometry:
 
     solids: list[TopoDS_Solid]
     material_names: list[str]
-    surfaces: list[TopoDS_Face | TopoDS_Shell]
+    surfaces: list[TopoDS_Face]
     surface_boundary_conditions: list[str]
 
     def __init__(
@@ -65,77 +75,119 @@ class Geometry:
         """Construct geometry from solids.
 
         Args:
-            solids: List of solids, where each solid is a build123d Solid, cadquery
+            solids: List of solids, where each solid is a build123d Solid, CadQuery
             Solid, or OCP TopoDS_Solid.
             material_names: List of materials. Must match length of solids.
+            surfaces: List of surfaces, where each surface is a build123d or Cadquery
+            Face or Shell, or an OCP TopoDS_Face or TopoDS_Shell.
+            surface_boundary_conditions: List of boundary condition names. Must match
+            length of surfaces.
         """
-        if (
-            (solids and not material_names)
-            or (material_names and not solids)
-            or (solids and material_names and len(solids) != len(material_names))
-        ):
+        if (solids and not material_names) or (material_names and not solids):
             raise ValueError(
                 "If solids or material_names are provided, both must be provided and match in length."
             )
 
-        if (
-            (surfaces and not surface_boundary_conditions)
-            or (surface_boundary_conditions and not surfaces)
-            or (
-                surfaces
-                and surface_boundary_conditions
-                and len(surfaces) != len(surface_boundary_conditions)
-            )
+        if (surfaces and not surface_boundary_conditions) or (
+            surface_boundary_conditions and not surfaces
         ):
             raise ValueError(
                 "If surfaces or surface_boundary_conditions are provided, both must be provided and match in length."
             )
 
         self.solids = []
-        if solids:
-            for i, s in enumerate(solids):
-                if isinstance(s, TopoDS_Solid):
-                    self.solids.append(s)
-                elif isinstance(s, Solid):
-                    if s.wrapped is None:
-                        raise ValueError(
-                            f"{s} {i} has no wrapped TopoDS_Solid. Is it valid?"
-                        )
-                    self.solids.append(s.wrapped)
-                else:
-                    raise TypeError(f"Solid {i} is of invalid type {type(s).__name__}")
+        self.material_names = []
+        if solids and material_names:
+            for i, (s, mat_name) in enumerate(zip(solids, material_names, strict=True)):
+                s_wrapped = (
+                    s if isinstance(s, TopoDS_Shape) else getattr(s, "wrapped", None)
+                )
 
-            self.material_names = list(material_names)
+                if s_wrapped is None:
+                    raise ValueError(
+                        f"{s} {i} has no wrapped TopoDS_Shape. Is it valid?"
+                    )
+
+                self.solids.append(s_wrapped)
+                self.material_names.append(mat_name)
 
         self.surfaces = []
-        if surfaces:
-            for i, s in enumerate(surfaces):
-                if isinstance(s, (TopoDS_Face, TopoDS_Shell)):
-                    self.surfaces.append(s)
-                elif isinstance(s, (Face, Shell)):  # type: ignore
+        self.surface_boundary_conditions = []
+        if surfaces and surface_boundary_conditions:
+            for i, (s, bc) in enumerate(
+                zip(surfaces, surface_boundary_conditions, strict=True)
+            ):
+                if isinstance(s, (Face, Shell)):
                     if s.wrapped is None:
                         raise ValueError(
-                            f"{s} {i} has no wrapped TopoDS_Face or TopoDS_Shell. Is it valid?"
+                            f"{s} {i} has no wrapped TopoDS_Shape. Is it valid?"
                         )
-                    self.surfaces.append(s.wrapped)
+                    s_wrapped = s.wrapped
+                else:
+                    s_wrapped = s
+
+                if isinstance(s_wrapped, TopoDS_Face):
+                    self.surfaces.append(s_wrapped)
+                    self.surface_boundary_conditions.append(bc)
+                elif isinstance(s_wrapped, TopoDS_Shell):
+                    child_faces = self._get_child_shapes(s_wrapped, TopoDS_Face)
+                    self.surfaces.extend(child_faces)
+                    self.surface_boundary_conditions.extend([bc] * len(child_faces))
+
                 else:
                     raise TypeError(
                         f"Surface {i} is of invalid type {type(s).__name__}"
                     )
-            self.surface_boundary_conditions = list(surface_boundary_conditions)
 
     @staticmethod
-    def _solids_from_shape(shape: TopoDS_Shape) -> list[TopoDS_Solid]:
+    @overload
+    def _get_child_shapes(
+        parent: TopoDS_Shape, shape_type: Type[TopoDS_Face]
+    ) -> list[TopoDS_Face]: ...
+
+    @staticmethod
+    @overload
+    def _get_child_shapes(
+        parent: TopoDS_Shape, shape_type: Type[TopoDS_Shell]
+    ) -> list[TopoDS_Shell]: ...
+
+    @staticmethod
+    @overload
+    def _get_child_shapes(
+        parent: TopoDS_Shape, shape_type: Type[TopoDS_Solid]
+    ) -> list[TopoDS_Solid]: ...
+
+    @staticmethod
+    def _get_child_shapes(
+        parent: TopoDS_Shape, shape_type: Type[TopoDS_Shape]
+    ) -> Sequence[TopoDS_Shape]:
+        """Return all the child shapes of this shape."""
+        type_map = {
+            "TopoDS_Face": TopAbs_ShapeEnum.TopAbs_FACE,
+            "TopoDS_Shell": TopAbs_ShapeEnum.TopAbs_SHELL,
+            "TopoDS_Solid": TopAbs_ShapeEnum.TopAbs_SOLID,
+        }
+
+        top_abs_type = type_map.get(shape_type.__name__)
+        if top_abs_type is None:
+            raise ValueError(f"Unsupported shape_type: {shape_type}")
+
+        shapes = []
+        explorer = TopExp_Explorer(parent, top_abs_type)
+        while explorer.More():
+            assert explorer.Current().ShapeType() == top_abs_type
+            shapes.append(explorer.Current())
+            explorer.Next()
+        return shapes
+
+    @classmethod
+    def _get_solids_from_shape(cls, shape: TopoDS_Shape) -> list[TopoDS_Solid]:
         """Return all the solids in this shape."""
-        solids = []
+        solids: list[TopoDS_Solid] = []
         if shape.ShapeType() == TopAbs_ShapeEnum.TopAbs_SOLID:
             solids.append(TopoDS.Solid_s(shape))
-        if shape.ShapeType() == TopAbs_ShapeEnum.TopAbs_COMPOUND:
-            explorer = TopExp_Explorer(shape, TopAbs_ShapeEnum.TopAbs_SOLID)
-            while explorer.More():
-                assert explorer.Current().ShapeType() == TopAbs_ShapeEnum.TopAbs_SOLID
-                solids.append(TopoDS.Solid_s(explorer.Current()))
-                explorer.Next()
+        elif shape.ShapeType() == TopAbs_ShapeEnum.TopAbs_COMPOUND:
+            solids = cls._get_child_shapes(shape, TopoDS_Solid)
         return solids
 
     # TODO(akoen): from_step and from_brep are not DRY
@@ -167,7 +219,7 @@ class Geometry:
         solids = []
         for i in range(reader.NbShapes()):
             shape = reader.Shape(i + 1)
-            solids.extend(cls._solids_from_shape(shape))
+            solids.extend(cls._get_solids_from_shape(shape))
 
         return cls(solids, material_names)
 
@@ -216,7 +268,7 @@ class Geometry:
 
         if shape.IsNull():
             raise ValueError(f"Could not import {filename}")
-        solids = cls._solids_from_shape(shape)
+        solids = cls._get_solids_from_shape(shape)
 
         logger.info(f"Importing {len(solids)} from {filename}")
         return cls(solids, material_names)
@@ -258,7 +310,7 @@ class Geometry:
 
         bldr.Perform()
         res = bldr.Shape()
-        res_solids = self._solids_from_shape(res)
+        res_solids = self._get_solids_from_shape(res)
 
         if (l0 := len(res_solids)) != (l1 := len(self.solids)):
             raise RuntimeError(

--- a/src/stellarmesh/geometry.py
+++ b/src/stellarmesh/geometry.py
@@ -13,9 +13,7 @@ import warnings
 from typing import (
     Protocol,
     Sequence,
-    TypeVar,
     overload,
-    runtime_checkable,
 )
 
 from build123d import Optional, Type

--- a/src/stellarmesh/mesh.py
+++ b/src/stellarmesh/mesh.py
@@ -372,13 +372,14 @@ class SurfaceMesh(Mesh):
 
         BRepMesh_IncrementalMesh(theShape=cmp, theParameters=params)
 
-        loc = TopLoc_Location()
         explorer = TopExp_Explorer(cmp, TopAbs_FACE)
         faces = []
         while explorer.More():
             face = TopoDS.Face_s(explorer.Current())
             faces.append(face)
             explorer.Next()
+
+        loc = TopLoc_Location()
 
         # NOTE: Gmsh import logic is at
         # https://github.com/live-clones/gmsh/blob/a20dc70a8bb9115185dd6a3b519f6bb3a1aec261/src/geo/GModelIO_OCC.cpp#L715
@@ -451,6 +452,7 @@ class SurfaceMesh(Mesh):
         with cls() as mesh:
             gmsh.model.add("stellarmesh_model")
 
+            # Solids
             material_solid_map = {}
             for s, m in zip(geometry.solids, geometry.material_names, strict=True):
                 dim_tags = cls._import_occ(s)
@@ -463,10 +465,26 @@ class SurfaceMesh(Mesh):
                 else:
                     material_solid_map[m].append(solid_tag)
 
-            gmsh.model.occ.synchronize()
+            # Faces
+            surface_bc_map = {}
+            for f, bc in zip(
+                geometry.faces, geometry.face_boundary_conditions, strict=True
+            ):
+                dim_tags = cls._import_occ(f)
+                if dim_tags[0][0] != 2:
+                    raise TypeError("Importing non-surface geometry.")
 
+                surface_tag = dim_tags[0][1]
+                if bc not in surface_bc_map:
+                    surface_bc_map[bc] = [surface_tag]
+                else:
+                    surface_bc_map[bc].append(surface_tag)
+
+            gmsh.model.occ.synchronize()
             for material, solid_tags in material_solid_map.items():
                 gmsh.model.add_physical_group(3, solid_tags, name=f"mat:{material}")
+            for bc, surface_tags in surface_bc_map.items():
+                gmsh.model.add_physical_group(2, surface_tags, name=f"boundary:{bc}")
 
             if type(options).__name__ == GmshSurfaceOptions.__name__:
                 cls._mesh_gmsh(options)  # type: ignore

--- a/src/stellarmesh/moab.py
+++ b/src/stellarmesh/moab.py
@@ -161,6 +161,8 @@ class DAGMCGroup(EntitySet):
 
 
 class DAGMCEntitySet(EntitySet):
+    """An entity set for a DAGMC topological surface or volume."""
+
     model: DAGMCModel
 
     @property
@@ -599,7 +601,7 @@ class DAGMCModel(MOABModel):
                 # sense.
                 adjacencies = gmsh.model.get_adjacencies(3, volume_tag)
                 surface_tags = adjacencies[1]
-                for i, surface_tag in enumerate(surface_tags):
+                for j, surface_tag in enumerate(surface_tags):
                     if surface_tag not in known_surfaces:
                         surface_set = model.create_surface(surface_tag)
                         known_surfaces[surface_tag] = surface_set
@@ -610,7 +612,7 @@ class DAGMCModel(MOABModel):
                         )
                         if (num_groups := len(surface_groups)) > 1:
                             raise ValueError(
-                                f"Surface with tag {surface_tag} and global_id {i} "
+                                f"Surface with tag {surface_tag} and global_id {j} "
                                 f"belongs to {num_groups} physical groups, should be 0 "
                                 f"or 1."
                             )

--- a/src/stellarmesh/moab.py
+++ b/src/stellarmesh/moab.py
@@ -160,10 +160,17 @@ class DAGMCGroup(EntitySet):
         self.model._core.remove_entity(self.handle, entity_set.handle)
 
 
-class DAGMCSurface(EntitySet):
-    """DAGMC surface entity."""
-
+class DAGMCEntitySet(EntitySet):
     model: DAGMCModel
+
+    @property
+    def groups(self) -> list[DAGMCGroup]:
+        """Get list of groups containing this volume."""
+        return [group for group in self.model.groups if self in group]
+
+
+class DAGMCSurface(DAGMCEntitySet):
+    """DAGMC surface entity."""
 
     @property
     def forward_volume(self) -> Optional[DAGMCVolume]:
@@ -211,6 +218,38 @@ class DAGMCSurface(EntitySet):
                 self.model._core.add_parent_child(vol.handle, self.handle)
 
     @property
+    def boundary(self) -> Optional[str]:
+        """Name of the boundary condition assigned to this surface."""
+        for group in self.groups:
+            if self in group and group.name.startswith("boundary:"):
+                return group.name[9:]
+        return None
+
+    @boundary.setter
+    def boundary(self, name: str):
+        existing_group = False
+        for group in self.model.groups:
+            if f"boundary:{name}" == group.name:
+                # Add volume to group matching specified name, unless the volume
+                # is already in it
+                if self in group:
+                    return
+                group.add(self)
+                existing_group = True
+
+            elif self in group and group.name.startswith("boundary:"):
+                # Remove volume from existing group
+                group.remove(self)
+
+        if not existing_group:
+            # Create new group and add entity
+            new_group = self.model.create_group(f"boundary:{name}")
+            new_group.global_id = (
+                max((g.global_id for g in self.model.groups), default=0) + 1
+            )
+            new_group.add(self)
+
+    @property
     def adjacent_volumes(self) -> list[DAGMCVolume]:
         """Get adjacent volumes.
 
@@ -226,10 +265,8 @@ class DAGMCSurface(EntitySet):
         return self.model._core.get_entities_by_type(self.handle, pymoab.types.MBTRI)
 
 
-class DAGMCVolume(EntitySet):
+class DAGMCVolume(DAGMCEntitySet):
     """DAGMC volume entity."""
-
-    model: DAGMCModel
 
     @property
     def adjacent_surfaces(self) -> list[DAGMCSurface]:
@@ -240,11 +277,6 @@ class DAGMCVolume(EntitySet):
         """
         child_entities = self.model._core.get_child_meshsets(self.handle)
         return [DAGMCSurface(self.model, e) for e in child_entities]
-
-    @property
-    def groups(self) -> list[DAGMCGroup]:
-        """Get list of groups containing this volume."""
-        return [group for group in self.model.groups if self in group]
 
     @property
     def material(self) -> Optional[str]:
@@ -553,7 +585,7 @@ class DAGMCModel(MOABModel):
                 if (num_groups := len(vol_groups)) != 1:
                     raise ValueError(
                         f"Volume with tag {volume_tag} and global_id {i} "
-                        f"belongs to {num_groups} physical groups, should be 1"
+                        f"belongs to {num_groups} physical groups, should be 1."
                     )
                 mat_name = gmsh.model.get_physical_name(3, vol_groups[0])
                 volume_set.material = mat_name[4:]
@@ -567,26 +599,43 @@ class DAGMCModel(MOABModel):
                 # sense.
                 adjacencies = gmsh.model.get_adjacencies(3, volume_tag)
                 surface_tags = adjacencies[1]
-                for surface_tag in surface_tags:
+                for i, surface_tag in enumerate(surface_tags):
                     if surface_tag not in known_surfaces:
-                        surface = model.create_surface(surface_tag)
-                        surface.forward_volume = volume_set
-                        known_surfaces[surface_tag] = surface
+                        surface_set = model.create_surface(surface_tag)
+                        known_surfaces[surface_tag] = surface_set
+
+                        surface_set.forward_volume = volume_set
+                        surface_groups = gmsh.model.get_physical_groups_for_entity(
+                            2, surface_tag
+                        )
+                        if (num_groups := len(surface_groups)) > 1:
+                            raise ValueError(
+                                f"Surface with tag {surface_tag} and global_id {i} "
+                                f"belongs to {num_groups} physical groups, should be 0 "
+                                f"or 1."
+                            )
+                        if num_groups == 1:
+                            boundary_name = gmsh.model.get_physical_name(
+                                2, surface_groups[0]
+                            )
+                            surface_set.boundary = boundary_name[9:]
 
                         # Write surface to MOAB. STL export/import is very efficient.
                         with tempfile.NamedTemporaryFile(
                             suffix=".stl", delete=True
                         ) as stl_file:
+                            # We add a temp dummy surface physical group to constrain
+                            # STL export.
                             group_tag = gmsh.model.add_physical_group(2, [surface_tag])
                             gmsh.write(stl_file.name)
                             gmsh.model.remove_physical_groups([(2, group_tag)])
-                            core.load_file(stl_file.name, surface.handle)
+                            core.load_file(stl_file.name, surface_set.handle)
 
                     else:
                         # Surface already has a forward volume, so this must be the
                         # reverse volume.
-                        surface = known_surfaces[surface_tag]
-                        surface.reverse_volume = volume_set
+                        surface_set = known_surfaces[surface_tag]
+                        surface_set.reverse_volume = volume_set
 
             all_entities = core.get_entities_by_handle(0)
             file_set = core.create_meshset()

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -66,15 +66,15 @@ def geom_bd_capped_torus():
         solids=solids,
         material_names=[""] * len(solids),
         surfaces=surfaces,
-        surface_boundary_conditions=["Reflecting"] * len(surfaces),
+        surface_boundary_conditions=["reflecting"] * len(surfaces),
     )
     return geom
 
 
 @pytest.fixture
-def geom_bd_single_torus_surface():
+def geom_bd_torus_single_surface():
     face: bd.Face = bd.Solid.make_torus(10, 1).face()  # type: ignore
-    geom = sm.Geometry(surfaces=[face], surface_boundary_conditions=["Vacuum"])
+    geom = sm.Geometry(surfaces=[face], surface_boundary_conditions=["vacuum"])
     return geom
 
 

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -1,5 +1,6 @@
 import build123d as bd
 import pytest
+
 import stellarmesh as sm
 
 
@@ -76,17 +77,6 @@ def geom_bd_torus_single_surface():
     face: bd.Face = bd.Solid.make_torus(10, 1).face()  # type: ignore
     geom = sm.Geometry(surfaces=[face], surface_boundary_conditions=["vacuum"])
     return geom
-
-
-@pytest.fixture
-def test_tmp(model_bd_capped_torus):
-    geom = sm.Geometry(
-        model_bd_capped_torus, material_names=[""] * len(model_bd_capped_torus)
-    )
-    geom_imprinted = geom.imprint()
-    from ocp_vscode import show
-
-    show(geom_imprinted.solids)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -47,6 +47,48 @@ def geom_imprintedboxes(model_bd_offsetboxes):
     return geom_imprinted
 
 
+@pytest.fixture
+def geom_bd_capped_torus():
+    faces = bd.ShapeList()
+    solids = [bd.Solid.make_torus(10, 1, major_angle=90)]
+    for _ in range(3):
+        s = bd.Solid.thicken(solids[-1].faces()[0], 1)
+        solids.append(s)
+
+    for s in solids:
+        faces.extend(s.faces())
+
+    xz_faces = faces.filter_by(bd.Plane.XZ)
+    yz_faces = faces.filter_by(bd.Plane.YZ)
+    surfaces = list(xz_faces + yz_faces)
+
+    geom = sm.Geometry(
+        solids=solids,
+        material_names=[""] * len(solids),
+        surfaces=surfaces,
+        surface_boundary_conditions=["Reflecting"] * len(surfaces),
+    )
+    return geom
+
+
+@pytest.fixture
+def geom_bd_single_torus_surface():
+    face: bd.Face = bd.Solid.make_torus(10, 1).face()  # type: ignore
+    geom = sm.Geometry(surfaces=[face], surface_boundary_conditions=["Vacuum"])
+    return geom
+
+
+@pytest.fixture
+def test_tmp(model_bd_capped_torus):
+    geom = sm.Geometry(
+        model_bd_capped_torus, material_names=[""] * len(model_bd_capped_torus)
+    )
+    geom_imprinted = geom.imprint()
+    from ocp_vscode import show
+
+    show(geom_imprinted.solids)
+
+
 @pytest.mark.parametrize(
     "fixture",
     [("model_bd_layered_torus"), ("model_ocp_layered_torus")],

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -6,19 +6,19 @@ from pathlib import Path
 
 import build123d as bd
 import gmsh
-import pytest
 import numpy as np
+import pytest
 
 import stellarmesh as sm
 
 from . import resources
 from .test_geometry import (
+    geom_bd_capped_torus,  # noqa: F401
+    geom_bd_torus_single_surface,  # noqa: F401
     model_bd_layered_torus,
     model_bd_nestedspheres,
     model_bd_offsetboxes,  # noqa: F401
     model_bd_sphere,
-    geom_bd_capped_torus,
-    geom_bd_single_torus_surface,
 )
 
 
@@ -169,7 +169,8 @@ def test_mesh_overlap(model_bd_stellarator_plasma):
 
 
 def test_mesh_surface_capped_torus_bcs(geom_bd_capped_torus):
-    # NOTE: In this test all surfaces are also members of volume surfaces
+    """Test material and BC assignments for a capped torus."""
+    # NOTE: In this test all surfaces are also members of solids
     for options in [sm.GmshSurfaceOptions(), sm.OCCSurfaceOptions()]:
         mesh = sm.SurfaceMesh.from_geometry(geom_bd_capped_torus, options)
         with mesh:
@@ -179,7 +180,7 @@ def test_mesh_surface_capped_torus_bcs(geom_bd_capped_torus):
                 *surface_bc_dim_tag
             )
             surface_bc_group_name = gmsh.model.get_physical_name(*surface_bc_dim_tag)
-            assert surface_bc_group_name == "boundary:Reflecting"
+            assert surface_bc_group_name == "boundary:reflecting"
             assert np.all(
                 surface_bc_tags == np.array([2, 3, 5, 6, 8, 9, 11, 12], dtype=np.int32)
             )
@@ -193,12 +194,22 @@ def test_mesh_surface_capped_torus_bcs(geom_bd_capped_torus):
             assert np.all(volume_mat_tags == np.array([1, 2, 3, 4], dtype=np.int32))
 
 
-def test_mesh_surface_single_torus_bc(geom_bd_single_torus_surface):
-    # NOTE: In this test all surfaces are also members of volume surfaces
+def test_mesh_torus_single_surface_bc(geom_bd_torus_single_surface):
     for options in [sm.GmshSurfaceOptions(), sm.OCCSurfaceOptions()]:
-        mesh = sm.SurfaceMesh.from_geometry(geom_bd_single_torus_surface, options)
+        mesh = sm.SurfaceMesh.from_geometry(geom_bd_torus_single_surface, options)
         with mesh:
             dim_tags = gmsh.model.get_physical_groups()
+
+            assert len(dim_tags) == 1, "Too many physical groups"
+
+            surface_bc_dim_tag = dim_tags[0]
+            surface_bc_tags = gmsh.model.get_entities_for_physical_group(
+                *surface_bc_dim_tag
+            )
+            surface_bc_group_name = gmsh.model.get_physical_name(*surface_bc_dim_tag)
+
+            assert surface_bc_group_name == "boundary:vacuum"
+            assert np.all(surface_bc_tags == np.array([1], dtype=np.int32))
 
 
 def test_mesh_export_exodus(model_bd_layered_torus, tmp_path: Path):


### PR DESCRIPTION
This PR adds the ability to mesh individual surfaces and tag them with boundary conditions.

Closes #6 
Closes #49 

Example:

``` python
import build123d as bd
from ocp_vscode import show
import stellarmesh as sm
import logging

logging.basicConfig() # Required in Jupyter to correctly set output stream
logging.getLogger("stellarmesh").setLevel(logging.DEBUG)

b1 = bd.Solid.make_box(1,1,1)
b2 = bd.Solid.thicken(b1.face(), 1)

faces = []
for b in [b1, b2]:
    for f in b.faces():
        print(f.wrapped.Orientation())
        f.label = str(f.wrapped.Orientation())[-10:]
        faces.append(f)
show(b1, b2, faces)
print(len(faces))

geom = sm.Geometry([b1, b2], surfaces=[b1.face()], surface_boundary_conditions=["reflective"], material_names=["unobtanium"]*2)
mesh = sm.SurfaceMesh.from_geometry(geom, sm.OCCSurfaceOptions())

mesh.write("tmp.msh")
dagmc_model = sm.DAGMCModel.from_mesh(mesh)
dagmc_model.write("dagmc.h5m")
```

`mbsize` output:

```
 mbsize -ll scratch/dagmc.h5m | grep -C 8 'NAME = boundary:'
Global id = 1
MBENTITYSET 4
        EntitySet 3
  Parent sets: (none)
  Child sets: (none)
  Sparse tags:
    GEOM_DIMENSION = 4 
    CATEGORY = Group
    NAME = boundary:reflective
  Adjacencies:
(none)
Dense tags:
  GLOBAL_ID = 1
```