### PR TITLE
Introduce benchmarks and do not extend OCP meshing arrays

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,4 +54,4 @@ jobs:
         env:
           OPENMC_CROSS_SECTIONS: ${{ github.workspace }}/cross_sections.xml
         run: |
-          python -m pytest --log-cli-level=INFO --ignore tests/test_examples.py
+          python -m pytest --log-cli-level=INFO --ignore tests/test_examples.py --ignore tests/test_mesh_benchmark.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dev = [
     "pip>=25.2",
     "pytest>=8.4.1",
     "pytest-cov>=6.2.1",
+    "pytest-benchmark>=5.1.0",
     "ruff>=0.12.8",
 ]
 

--- a/tests/test_mesh_benchmark.py
+++ b/tests/test_mesh_benchmark.py
@@ -26,7 +26,7 @@ def test_benchmark_mesh(model_bd_layered_torus, benchmark, mesh_options):
     mesh = benchmark.pedantic(
         sm.SurfaceMesh.from_geometry,
         args=(geom, mesh_options),
-        iterations=1,
+        rounds=3,
     )
     with mesh:
         num_nodes = len(gmsh.model.mesh.get_nodes()[0])

--- a/tests/test_mesh_benchmark.py
+++ b/tests/test_mesh_benchmark.py
@@ -1,0 +1,33 @@
+import logging
+
+import gmsh
+import pytest
+
+import stellarmesh as sm
+
+from .test_geometry import model_bd_layered_torus  # noqa: F401
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.parametrize(
+    "mesh_options",
+    [
+        sm.OCCSurfaceOptions(tol_angular_deg=0.1),
+        sm.GmshSurfaceOptions(curvature_target=45, num_threads=8),
+    ],
+    ids=["OCC", "Gmsh"],
+)
+def test_benchmark_mesh(model_bd_layered_torus, benchmark, mesh_options):
+    geom = sm.Geometry(
+        solids=model_bd_layered_torus, material_names=[""] * len(model_bd_layered_torus)
+    )
+
+    mesh = benchmark.pedantic(
+        sm.SurfaceMesh.from_geometry,
+        args=(geom, mesh_options),
+        iterations=1,
+    )
+    with mesh:
+        num_nodes = len(gmsh.model.mesh.get_nodes()[0])
+        logger.info(f"Model has {num_nodes} nodes")


### PR DESCRIPTION
Introduce performance benchmarking. In initial tests, OCC is ~72x faster than GMSH for a similar number of mesh elements.

```
----------------------------------------------------------------------------------------------- benchmark: 2 tests -----------------------------------------------------------------------------------------------
Name (time in ms)                     Min                    Max                   Mean              StdDev                 Median                   IQR            Outliers     OPS            Rounds  Iterations
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_benchmark_mesh[OCC]         738.7902 (1.0)         765.1772 (1.0)         752.7647 (1.0)       13.2627 (1.0)         754.3266 (1.0)         19.7903 (1.0)           1;0  1.3284 (1.0)           3           1
test_benchmark_mesh[Gmsh]     53,297.6530 (72.14)    54,735.1186 (71.53)    54,005.4203 (71.74)    718.9837 (54.21)    53,983.4894 (71.57)    1,078.0992 (54.48)         1;0  0.0185 (0.01)          3           1
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```
GMSH Mesh
<img width="1624" height="1183" alt="image" src="https://github.com/user-attachments/assets/7a2c285f-b31a-42b5-85ef-30606356b5ba" />

OCC Mesh
<img width="2129" height="1435" alt="image" src="https://github.com/user-attachments/assets/5a7d4737-9df1-4de5-9766-fa3f7ec9907f" />
